### PR TITLE
[REEF-1820] Allow to specify node names and relaxLocality flag settin…

### DIFF
--- a/lang/cs/Org.Apache.REEF.Bridge/EvaluatorRequestorClr2Java.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/EvaluatorRequestorClr2Java.cpp
@@ -53,7 +53,7 @@ namespace Org {
               ManagedLog::LOGGER->LogStart("EvaluatorRequestorClr2Java::Submit");
               JNIEnv *env = RetrieveEnv(_jvm);
               jclass jclassEvaluatorRequestor = env->GetObjectClass(_jobjectEvaluatorRequestor);
-              jmethodID jmidSubmit = env->GetMethodID(jclassEvaluatorRequestor, "submit", "(IIILjava/lang/String;Ljava/lang/String;)V");
+              jmethodID jmidSubmit = env->GetMethodID(jclassEvaluatorRequestor, "submit", "(IIIZLjava/lang/String;Ljava/lang/String;Ljava/util/ArrayList;)V");
 
               if (jmidSubmit == NULL) {
                 fprintf(stdout, " jmidSubmit is NULL\n");
@@ -66,8 +66,10 @@ namespace Org {
                 request->Number,
                 request->MemoryMegaBytes,
                 request->VirtualCore,
+                request->RelaxLocality,
                 JavaStringFromManagedString(env, request->Rack),
-                JavaStringFromManagedString(env, request->RuntimeName));
+                JavaStringFromManagedString(env, request->RuntimeName),
+                JavaArrayListFromManagedList(env, request->NodeNames));
               ManagedLog::LOGGER->LogStop("EvaluatorRequestorClr2Java::Submit");
             }
 

--- a/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
+++ b/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.cpp
@@ -70,6 +70,21 @@ jstring JavaStringFromManagedString(
   return env->NewString((const jchar*)wch, managedString->Length);
 }
 
+jobject JavaArrayListFromManagedList(
+    JNIEnv *env,
+    System::Collections::Generic::List<String^>^ managedNodeNames) {
+
+    jclass arrayListClazz = (*env).FindClass("java/util/ArrayList");
+    jobject arrayListObj = (*env).NewObject(arrayListClazz, (*env).GetMethodID(arrayListClazz, "<init>", "()V"));
+
+    for each (String^ nodeName in managedNodeNames)
+    {
+        jstring nodeNamestr = JavaStringFromManagedString(env, nodeName);
+        (*env).CallBooleanMethod(arrayListObj, (*env).GetMethodID(arrayListClazz, "add", "(Ljava/lang/Object;)Z"), nodeNamestr);
+    }
+    return arrayListObj;
+}
+
 void HandleClr2JavaError(
   JNIEnv *env,
   String^ errorMessage,

--- a/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.h
+++ b/lang/cs/Org.Apache.REEF.Bridge/InteropUtil.h
@@ -48,6 +48,10 @@ jstring JavaStringFromManagedString(
   JNIEnv *env,
   String^ managedString);
 
+jobject JavaArrayListFromManagedList(
+    JNIEnv *env,
+    System::Collections::Generic::List<String^>^ managedNodeNames);
+
 array<byte>^ ManagedByteArrayFromJavaByteArray(
   JNIEnv *env,
   jbyteArray javaByteArray);

--- a/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/EvaluatorRequestor.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Bridge/Events/EvaluatorRequestor.cs
@@ -64,7 +64,8 @@ namespace Org.Apache.REEF.Driver.Bridge.Events
 
         public void Submit(IEvaluatorRequest request)
         {
-            LOGGER.Log(Level.Info, "Submitting request for {0} evaluators and {1} MB memory and  {2} core to rack {3} and runtime {4}.", request.Number, request.MemoryMegaBytes, request.VirtualCore, request.Rack, request.RuntimeName);
+            LOGGER.Log(Level.Info, "Submitting request for {0} evaluators and {1} MB memory and  {2} core to rack {3} runtime {4}, nodeNames to schedule {5} and RelaxLocality is {6}.", 
+                request.Number, request.MemoryMegaBytes, request.VirtualCore, request.Rack, request.RuntimeName, string.Join(",", request.NodeNames.ToArray()), request.RelaxLocality);
             lock (Evaluators)
             {
                 for (var i = 0; i < request.Number; i++)

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequest.cs
@@ -16,6 +16,8 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.Serialization;
 
 namespace Org.Apache.REEF.Driver.Evaluator
@@ -27,37 +29,43 @@ namespace Org.Apache.REEF.Driver.Evaluator
     internal class EvaluatorRequest : IEvaluatorRequest
     {
         internal EvaluatorRequest()
-            : this(0, 0, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty)
+            : this(0, 0, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true)
         {
         }
 
         internal EvaluatorRequest(int number, int megaBytes)
-            : this(number, megaBytes, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty)
+            : this(number, megaBytes, 1, string.Empty, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true)
         {
         }
 
         internal EvaluatorRequest(int number, int megaBytes, int core)
-            : this(number, megaBytes, core, string.Empty, Guid.NewGuid().ToString("N"), string.Empty)
+            : this(number, megaBytes, core, string.Empty, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true)
         {
         }
 
         internal EvaluatorRequest(int number, int megaBytes, string rack)
-            : this(number, megaBytes, 1, rack, Guid.NewGuid().ToString("N"), string.Empty)
+            : this(number, megaBytes, 1, rack, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true)
         {
         }
 
         internal EvaluatorRequest(int number, int megaBytes, int core, string rack)
-            : this(number, megaBytes, core, rack, Guid.NewGuid().ToString("N"), string.Empty)
+            : this(number, megaBytes, core, rack, Guid.NewGuid().ToString("N"), string.Empty, Enumerable.Empty<string>().ToList(), true)
         {
         }
 
-        internal EvaluatorRequest(int number, int megaBytes, int core, string rack, string evaluatorBatchId)
-            : this(number, megaBytes, core, rack, evaluatorBatchId, string.Empty)
+        internal EvaluatorRequest(int number, int megaBytes, int core, string rack, string evaluatorBatchId, List<string> nodeNames)
+            : this(number, megaBytes, core, rack, evaluatorBatchId, string.Empty, nodeNames, true)
 
         {
         }
 
-        internal EvaluatorRequest(int number, int megaBytes, int core, string rack, string evaluatorBatchId, string runtimeName)
+        internal EvaluatorRequest(int number, int megaBytes, int core, string rack, string evaluatorBatchId, List<string> nodeNames, bool relaxLocality)
+           : this(number, megaBytes, core, rack, evaluatorBatchId, string.Empty, nodeNames, relaxLocality)
+
+        {
+        }
+
+        internal EvaluatorRequest(int number, int megaBytes, int core, string rack, string evaluatorBatchId, string runtimeName, List<string> nodeNames, bool relaxLocality)
         {
             Number = number;
             MemoryMegaBytes = megaBytes;
@@ -65,6 +73,8 @@ namespace Org.Apache.REEF.Driver.Evaluator
             Rack = rack;
             EvaluatorBatchId = evaluatorBatchId;
             RuntimeName = runtimeName;
+            NodeNames = nodeNames;
+            RelaxLocality = relaxLocality;
         }
 
         [DataMember]
@@ -84,6 +94,12 @@ namespace Org.Apache.REEF.Driver.Evaluator
 
         [DataMember]
         public string RuntimeName { get; private set; }
+
+        [DataMember]
+        public List<string> NodeNames { get; private set; }
+
+        [DataMember]
+        public bool RelaxLocality { get; private set; }
 
         internal static EvaluatorRequestBuilder NewBuilder()
         {

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequestBuilder.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/EvaluatorRequestBuilder.cs
@@ -16,6 +16,8 @@
 // under the License.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Org.Apache.REEF.Common.Runtime;
 
 namespace Org.Apache.REEF.Driver.Evaluator
@@ -25,6 +27,8 @@ namespace Org.Apache.REEF.Driver.Evaluator
         private string _evaluatorBatchId;
         private string _rackName;
         private string _runtimeName;
+        private List<string> _nodeNames;
+        private bool _relaxLocality;
 
         internal EvaluatorRequestBuilder(IEvaluatorRequest request)
         {
@@ -34,6 +38,8 @@ namespace Org.Apache.REEF.Driver.Evaluator
             _evaluatorBatchId = request.EvaluatorBatchId;
             _rackName = request.Rack;
             _runtimeName = request.RuntimeName;
+            _nodeNames = request.NodeNames;
+            _relaxLocality = request.RelaxLocality;
         }
 
         internal EvaluatorRequestBuilder()
@@ -44,6 +50,8 @@ namespace Org.Apache.REEF.Driver.Evaluator
             _rackName = string.Empty;
             _evaluatorBatchId = Guid.NewGuid().ToString("N");
             _runtimeName = string.Empty;
+            _nodeNames = Enumerable.Empty<string>().ToList();
+            _relaxLocality = true;
         }
 
         public int Number { get; private set; }
@@ -95,6 +103,17 @@ namespace Org.Apache.REEF.Driver.Evaluator
         }
 
         /// <summary>
+        /// Set the node names to do the request for.
+        /// </summary>
+        /// <param name="nodeNames"></param>
+        /// <returns>this</returns>
+        public EvaluatorRequestBuilder SetNodeNames(List<string> nodeNames)
+        {
+            _nodeNames = nodeNames;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the batch ID for requested evaluators in the same request. The batch of Evaluators requested in the 
         /// same request will have the same Evaluator Batch ID.
         /// </summary>
@@ -117,12 +136,23 @@ namespace Org.Apache.REEF.Driver.Evaluator
         }
 
         /// <summary>
+        /// Set the relax locality to do the request for.
+        /// </summary>
+        /// <param name="relaxLocality"></param>
+        /// <returns>this</returns>
+        public EvaluatorRequestBuilder SetRelaxLocality(bool relaxLocality)
+        {
+            _relaxLocality = relaxLocality;
+            return this;
+        }
+
+        /// <summary>
         /// Build the EvaluatorRequest.
         /// </summary>
         /// <returns></returns>
         public IEvaluatorRequest Build()
         {
-            return new EvaluatorRequest(Number, MegaBytes, VirtualCore, rack: _rackName, evaluatorBatchId: _evaluatorBatchId, runtimeName: _runtimeName);
+            return new EvaluatorRequest(Number, MegaBytes, VirtualCore, rack: _rackName, evaluatorBatchId: _evaluatorBatchId, runtimeName: _runtimeName, nodeNames: _nodeNames, relaxLocality: _relaxLocality);
         }
     }
 }

--- a/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorRequest.cs
+++ b/lang/cs/Org.Apache.REEF.Driver/Evaluator/IEvaluatorRequest.cs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System.Collections.Generic;
+
 namespace Org.Apache.REEF.Driver.Evaluator
 {
     /// <summary>
@@ -43,6 +45,11 @@ namespace Org.Apache.REEF.Driver.Evaluator
         string Rack { get; }
 
         /// <summary>
+        /// The desired node names for the Evaluator to be allocated on.
+        /// </summary>
+        List<string> NodeNames { get; }
+
+        /// <summary>
         /// The batch ID for requested evaluators. Evaluators requested in the same batch
         /// will have the same Batch ID.
         /// </summary>
@@ -52,5 +59,22 @@ namespace Org.Apache.REEF.Driver.Evaluator
         /// The name of the runtime to allocate teh evaluator on
         /// </summary>
         string RuntimeName { get; }
+
+        /// <summary>
+        /// For a request at a network hierarchy level, set whether locality can be relaxed to that level and beyond.
+        ///
+        /// If the flag is off on a rack-level ResourceRequest, containers at that request's priority 
+        /// will not be assigned to nodes on that request's rack unless requests specifically for 
+        /// those nodes have also been submitted.
+        /// 
+        /// If the flag is off on an ANY-level ResourceRequest, containers at that request's priority 
+        /// will only be assigned on racks for which specific requests have also been submitted.
+        /// 
+        /// For example, to request a container strictly on a specific node, the corresponding rack-level 
+        /// and any-level requests should have locality relaxation set to false. Similarly, 
+        /// to request a container strictly on a specific rack, 
+        /// the corresponding any-level request should have locality relaxation set to false.
+        /// </summary>
+        bool RelaxLocality { get; }
     }
 }

--- a/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/EvaluatorRequestorBridge.java
+++ b/lang/java/reef-bridge-java/src/main/java/org/apache/reef/javabridge/EvaluatorRequestorBridge.java
@@ -66,8 +66,10 @@ public final class EvaluatorRequestorBridge extends NativeBridge {
   public void submit(final int evaluatorsNumber,
                      final int memory,
                      final int virtualCore,
+                     final boolean relaxLocality,
                      final String rack,
-                     final String runtimeName) {
+                     final String runtimeName,
+                     final List<String> nodeNames) {
     if (this.isBlocked) {
       throw new RuntimeException("Cannot request additional Evaluator, this is probably because " +
           "the Driver has crashed and restarted, and cannot ask for new container due to YARN-2433.");
@@ -85,6 +87,8 @@ public final class EvaluatorRequestorBridge extends NativeBridge {
           .setMemory(memory)
           .setNumberOfCores(virtualCore)
           .setRuntimeName(runtimeName)
+          .setRelaxLocality(relaxLocality)
+          .addNodeNames(nodeNames)
           .build();
 
       LOG.log(Level.FINE, "submitting evaluator request {0}", request);

--- a/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/driver/evaluator/EvaluatorRequest.java
@@ -40,6 +40,7 @@ public final class EvaluatorRequest {
   private final List<String> nodeNames;
   private final List<String> rackNames;
   private final String runtimeName;
+  private final boolean relaxLocality;
 
   EvaluatorRequest(final int number,
                    final int megaBytes,
@@ -55,12 +56,24 @@ public final class EvaluatorRequest {
                    final List<String> nodeNames,
                    final List<String> rackNames,
                    final String runtimeName) {
+    this(number, megaBytes, cores, nodeNames, rackNames, runtimeName, true);
+  }
+
+
+  EvaluatorRequest(final int number,
+                   final int megaBytes,
+                   final int cores,
+                   final List<String> nodeNames,
+                   final List<String> rackNames,
+                   final String runtimeName,
+                   final boolean relaxLocality) {
     this.number = number;
     this.megaBytes = megaBytes;
     this.cores = cores;
     this.nodeNames = nodeNames;
     this.rackNames = rackNames;
     this.runtimeName = runtimeName;
+    this.relaxLocality = relaxLocality;
   }
 
   /**
@@ -137,6 +150,16 @@ public final class EvaluatorRequest {
   }
 
   /**
+   * Access the relaxlocality flag.
+   *
+   * @return the value of relaxLocality. If not set return true.
+   */
+  public boolean getRelaxLocality() {
+    return relaxLocality;
+  }
+
+
+  /**
    * {@link EvaluatorRequest}s are build using this Builder.
    */
   public static class Builder<T extends Builder> implements org.apache.reef.util.Builder<EvaluatorRequest> {
@@ -147,6 +170,7 @@ public final class EvaluatorRequest {
     private final List<String> nodeNames = new ArrayList<>();
     private final List<String> rackNames = new ArrayList<>();
     private String runtimeName = "";
+    private boolean relaxLocality = true; //if not set, default to true
 
     @Private
     public Builder() {
@@ -163,6 +187,7 @@ public final class EvaluatorRequest {
       setMemory(request.getMegaBytes());
       setNumberOfCores(request.getNumberOfCores());
       setRuntimeName(request.getRuntimeName());
+      setRelaxLocality(request.getRelaxLocality());
       for (final String nodeName : request.getNodeNames()) {
         addNodeName(nodeName);
       }
@@ -233,6 +258,21 @@ public final class EvaluatorRequest {
     }
 
     /**
+     * Adds node names.They are the preferred locations where the evaluator should
+     * run on. If any of the node is available, the RM will try to allocate the
+     * evaluator there
+     *
+     * @param nodeNamesList preferred node names
+     * @return this Builder.
+     */
+    public T addNodeNames(final List<String> nodeNamesList) {
+      if(nodeNamesList != null) {
+        this.nodeNames.addAll(nodeNamesList);
+      }
+      return (T) this;
+    }
+
+    /**
      * Adds a rack name. It is the preferred location where the evaluator should
      * run on. If the rack is available, the RM will try to allocate the
      * evaluator in one of its nodes. The RM will try to match node names first,
@@ -247,11 +287,25 @@ public final class EvaluatorRequest {
     }
 
     /**
+     * A boolean relaxLocality flag defaulting to true, which tells the ResourceManager
+     * if the application wants locality to be loose (i.e. allows fall-through to rack or any)
+     * or strict (i.e. specify hard constraint on resource allocation).
+     *
+     * @param relaxLocalityFlg locality relaxation is enabled with this ResourceRequest
+     * @return this Builder.
+     */
+    public T setRelaxLocality(final boolean relaxLocalityFlg) {
+      this.relaxLocality = relaxLocalityFlg;
+      return (T) this;
+    }
+
+    /**
      * Builds the {@link EvaluatorRequest}.
      */
     @Override
     public EvaluatorRequest build() {
-      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames, this.rackNames, this.runtimeName);
+      return new EvaluatorRequest(this.n, this.megaBytes, this.cores, this.nodeNames,
+                                  this.rackNames, this.runtimeName, this.relaxLocality);
     }
   }
 }

--- a/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
+++ b/lang/java/reef-common/src/main/java/org/apache/reef/runtime/common/driver/EvaluatorRequestorImpl.java
@@ -82,21 +82,17 @@ public final class EvaluatorRequestorImpl implements EvaluatorRequestor {
       throw new IllegalArgumentException("Runtime name cannot be null");
     }
     // for backwards compatibility, we will always set the relax locality flag
-    // to true unless the user configured racks, in which case we will check for
-    // the ANY modifier (*), if not there, then we won't relax the locality
-    boolean relaxLocality = true;
+    // to true unless the user has set it to false in the request, in which case
+    // we will check for the ANY modifier (*), if there, then we relax the
+    // locality regardless of the value set in the request.
+    boolean relaxLocality = req.getRelaxLocality();
     if (!req.getRackNames().isEmpty()) {
       for (final String rackName : req.getRackNames()) {
         if (Constants.ANY_RACK.equals(rackName)) {
           relaxLocality = true;
           break;
         }
-        relaxLocality = false;
       }
-    }
-    // if the user specified any node, then we assume they do not want to relax locality
-    if (!req.getNodeNames().isEmpty()) {
-      relaxLocality = false;
     }
 
     try (LoggingScope ls = this.loggingScopeFactory.evaluatorSubmit(req.getNumber())) {


### PR DESCRIPTION
…g when requesting evaluators.

      - Add two new member variables to lang/cs/Org.Apache.REEF.Driver.Evaluator/EvaluatorRequestBuilder.cs
      to allow caller to specify the node names and relaxLocality setting while building EvaluatorRequest.
      If caller doesn't want to specify nodeNames then an empty list is propagated to Java layer. Default
      value of relaxLocality is TRUE. YARN RM will try to schedule TASK on the nodes specified in nodeNames.
      relaxLocality for a request at a network hierarchy level, set whether locality can be relaxed
      to that level and beyond.If the flag is off on a rack-level ResourceRequest, containers at
      that request's priority will not be assigned to nodes on that request's rack unless requests
      specifically for those nodes have also been submitted.
						If the relaxLocality flag is off on an ANY-level ResourceRequest, containers
						at that request's priority will only be assigned on racks for which specific
						requests have also been submitted.

    JIRA:
      [REEF-1820](https://issues.apache.org/jira/browse/REEF-1820)

    Pull Request:
      This closes #